### PR TITLE
Fixed problems of compiling with Unikraft v0.12

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -62,11 +62,10 @@
  * 4. Transition EBT allocator -> Mimalloc:
  *    We transition as soon as the TLS has been allocated and the %fs register
  *    set. This is checked at every EBT allocation by inspecting
- *    uk_thread_current()->prv which typically points to the thread local
- *    storage. Since memory allocations might happen during Mimalloc's
- *    initialization itself (e.g. calls to malloc() by pthread) the early boot
- *    time allocator continues to satisfy requests until Mimalloc is ready
- *    (after mi_process_load() returned).
+ *    uk_thread_current()->tlsp. Since memory allocations might happen during
+ *    Mimalloc's initialization itself (e.g. calls to malloc() by pthread) the
+ *    early boot time allocator continues to satisfy requests until Mimalloc
+ *    is ready (after mi_process_load() returned).
  */
 
 /* Minimum heap size (size of an arena)
@@ -88,7 +87,7 @@ static inline int _tls_ready(void)
 	/* Is the thread local storage ready? */
 	struct uk_thread *current = uk_thread_current();
 
-	return current && current->prv != NULL;
+	return current && current->tlsp != NULL;
 }
 
 /* boot-time malloc interface */

--- a/include/uk/mimalloc_impl.h
+++ b/include/uk/mimalloc_impl.h
@@ -41,6 +41,7 @@
 #define __LIBMIMALLOC_IMPL_H__
 
 #include <uk/alloc.h>
+#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I am trying to use mimalloc with Unikraft v0.12.0 (current stable version), and the mimalloc library doesn't compile. It seems that the `uk_thread` struct is modified after the original porting of mimalloc. Thus I made it work according to the context given.

I only tested this fix on app-redis and app-helloworld with QEMU 4.2.1. It worked well for any memory sizes above 256M. :)

See the diff for details, it's simple. Forgive me if I did anything wrong.