### PR TITLE
lib-mimalloc:Update library to 2.1.2

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -39,7 +39,7 @@ $(eval $(call addlib_s,libmimalloc,$(CONFIG_LIBMIMALLOC)))
 ################################################################################
 # Sources
 ################################################################################
-LIBMIMALLOC_VERSION=1.6.1
+LIBMIMALLOC_VERSION=2.1.2
 LIBMIMALLOC_URL=https://github.com/microsoft/mimalloc/archive/v$(LIBMIMALLOC_VERSION).zip
 LIBMIMALLOC_DIR=mimalloc-$(LIBMIMALLOC_VERSION)
 


### PR DESCRIPTION
Issue https://github.com/unikraft/lib-mimalloc/issues/6
At line 42 in Makefile.uk update version from `LIBMIMALLOC_VERSION=1.6.1` to `LIBMIMALLOC_VERSION=2.1.2`