### PR TITLE
Adapt to lib-musl and the new threading interface

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -8,9 +8,8 @@ menuconfig LIBMIMALLOC
 	bool "mimalloc: a compact general purpose allocator with excellent performance"
 	default n
 	select LIBUKSCHED
-	select LIBNEWLIBC
+	select LIBMUSL
 	select LIBPOSIX_SYSINFO
-	select LIBPTHREAD_EMBEDDED
 	select LIBUKALLOCREGION
 if LIBMIMALLOC
 	config MIMALLOC_DEBUG

--- a/glue.c
+++ b/glue.c
@@ -62,7 +62,7 @@
  * 4. Transition EBT allocator -> Mimalloc:
  *    We transition as soon as the TLS has been allocated and the %fs register
  *    set. This is checked at every EBT allocation by inspecting
- *    uk_thread_current()->prv which typically points to the thread local
+ *    uk_thread_current()->priv which typically points to the thread local
  *    storage. Since memory allocations might happen during Mimalloc's
  *    initialization itself (e.g. calls to malloc() by pthread) the early boot
  *    time allocator continues to satisfy requests until Mimalloc is ready
@@ -88,7 +88,7 @@ static inline int _tls_ready(void)
 	/* Is the thread local storage ready? */
 	struct uk_thread *current = uk_thread_current();
 
-	return current && current->prv != NULL;
+	return current && current->priv != NULL;
 }
 
 /* boot-time malloc interface */

--- a/include/uk/mimalloc.h
+++ b/include/uk/mimalloc.h
@@ -35,6 +35,7 @@
 #define __LIBMIMALLOC_H__
 
 #include <uk/alloc.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/uk/mimalloc_impl.h
+++ b/include/uk/mimalloc_impl.h
@@ -41,6 +41,7 @@
 #define __LIBMIMALLOC_IMPL_H__
 
 #include <uk/alloc.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR introduces three changes:

1. `Makefile.uk`: Change the library dependency from `lib-newlib` and `lib-pthread-embedded` to `lib-musl`. The `musl` library also includes a `pthread` interface.
2. `glue.c`: Change the obsolete variable names to adapt to the new threading interface.
3. `mimalloc.h` and `mimalloc_impl.h`: Include a new header to silence compiler errors.

This PR is part of an ongoing process of porting the latest mimalloc allocator to the latest (v0.17.0) Unikraft core. @RaduNichita @razvanvirtan @razvand 

With this PR, alongside [an addition of `stdatomic.h` to the MUSL library](https://github.com/unikraft/lib-musl/pull/80), `lib-mimalloc` (based on v1.6.3 of the mimalloc allocator) can now be compiled using `lib-musl` for Unikraft core v0.17.0.

Signed-off-by: Yang Hu <yanghuu531@gmail.com>